### PR TITLE
feat(auth): Cloudflare Pages環境での認証初期化問題の修正 (TPC-135)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__backlog__get_issue",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(npx eslint:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": []
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,192 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Tech Post Cast is a monorepo AI-powered podcast generation service that creates daily tech podcasts from Qiita articles. The system supports both public content and personalized subscription-based program generation.
+
+## Essential Commands
+
+### Development
+```bash
+# Start development servers
+yarn start:api-backend      # API Backend (port 3001)
+yarn start:backend          # Content generation backend (port 3000) 
+yarn start:lp-frontend      # Landing page frontend
+yarn start:line-bot         # LINE Bot development
+
+# Database operations
+yarn generate-prisma       # Generate Prisma client
+yarn deploy-migration-prisma # Apply database migrations
+yarn seed-prisma          # Seed database with sample data
+```
+
+### Building
+```bash
+# Build individual apps
+yarn build:api-backend     # Build API backend
+yarn build-backend         # Build content generation backend
+yarn build:lp-frontend     # Build landing page frontend
+
+# Build with dependencies
+yarn build-for-backend     # Build commons + database + backend
+yarn build:for-api-backend # Build commons + database + api-backend
+```
+
+### Testing
+```bash
+yarn test                  # Run all tests
+yarn test-backend          # Test backend only
+yarn test-commons          # Test commons package
+yarn test-database         # Test database package
+```
+
+### API Documentation
+```bash
+yarn generate:api-spec     # Generate all API specs
+yarn generate:api-client   # Generate API client from specs
+```
+
+## Architecture Overview
+
+### Repository Structure
+- **apps/**: Main applications
+  - `api-backend/`: User-facing REST API (NestJS)
+  - `backend/`: Content generation API (NestJS) 
+  - `lp-frontend/`: Landing page & dashboard (Nuxt3)
+  - `liff-frontend/`: LINE LIFF app (Nuxt3)
+  - `line-bot/`: LINE Bot (Hono on Cloudflare Workers)
+  - `infra/`: AWS CDK infrastructure (deprecated)
+- **packages/**: Shared packages
+  - `database/`: Prisma schema and client
+  - `commons/`: Shared utilities
+
+### Technology Stack
+- **Backend**: NestJS, PostgreSQL with Prisma, Clerk Auth
+- **Frontend**: Nuxt3, Vue3, Vuetify, TypeScript
+- **AI/ML**: OpenAI, Google AI, Mastra framework
+- **Infrastructure**: AWS Cloud Run, CloudFront, RDS
+- **Storage**: AWS S3, Cloudflare R2
+
+## Critical Implementation Patterns
+
+### NestJS Repository Pattern (Mandatory)
+
+Always implement the repository pattern with interfaces:
+
+```typescript
+// 1. Domain interface (src/domains/{domain}/{domain}.repository.interface.ts)
+export interface IUsersRepository {
+  findById(id: string): Promise<User | null>;
+}
+
+// 2. Infrastructure implementation (src/infrastructure/database/{domain}/{domain}.repository.ts)
+@Injectable()
+export class UsersRepository implements IUsersRepository {
+  constructor(private prisma: PrismaService) {}
+  // Implementation
+}
+
+// 3. DI configuration in module
+providers: [
+  {
+    provide: 'UsersRepository',
+    useClass: UsersRepository,
+  },
+]
+
+// 4. Service injection
+constructor(
+  @Inject('UsersRepository')
+  private readonly repository: IUsersRepository,
+) {}
+```
+
+### Test Data Management (Mandatory)
+
+Always use factory classes for test data - never create inline test objects:
+
+```typescript
+// Create factory class (src/test/factories/{entity}.factory.ts)
+export class UserFactory {
+  static createUser(overrides: Partial<User> = {}): User {
+    return {
+      id: 'user-1',
+      email: 'test@example.com',
+      name: 'Test User',
+      ...overrides,
+    };
+  }
+}
+
+// Use in tests
+const user = UserFactory.createUser({ name: 'Custom Name' });
+```
+
+### Directory Structure Standards
+
+```
+src/
+├── domains/                    # Domain layer with interfaces
+│   └── {domain}/
+│       ├── {domain}.repository.interface.ts
+│       └── {domain}.service.ts
+├── infrastructure/             # Infrastructure implementations
+│   └── database/
+│       └── {domain}/
+│           └── {domain}.repository.ts
+├── controllers/               # API controllers with DTOs
+├── test/
+│   └── factories/            # Test data factories
+└── types/
+    └── errors/              # Custom error types
+```
+
+## Development Guidelines
+
+### TypeScript Standards
+- Use strict mode (`strict: true`)
+- Explicit return types for all functions
+- No `any` types - define explicit types
+- Comprehensive error handling
+
+### Testing Requirements
+- Use factory classes for all test data
+- Mock external dependencies with `jest-mock-extended`
+- Follow Arrange-Act-Assert pattern
+- Test both success and error scenarios
+
+### API Design
+- Use DTOs for request/response validation
+- Implement OpenAPI documentation with `@nestjs/swagger`
+- Resource ownership validation for user data
+- Consistent error responses
+
+### Frontend Patterns (Nuxt3)
+- Use Composition API with TypeScript
+- Domain-specific composables for API calls
+- Progressive loading with proper error states
+- Vuetify for UI components
+
+## Key Database Entities
+
+- `AppUser`: Clerk-integrated user management
+- `PersonalizedFeed`: User-defined content filters with Qiita integration
+- `HeadlineTopicProgram`: Daily generated podcast episodes
+- `QiitaPost`: Sourced articles with AI-generated summaries
+- `Subscription`: Stripe-integrated billing and feature access
+
+## Branch Naming
+- Features: `feature/TPC-XXX` or `feature/description`
+- Fixes: `fix/TPC-XXX` or `fix/description`
+- Refactoring: `refactor/description`
+
+## Important Notes
+
+- The codebase uses Yarn workspaces - always run commands from root
+- Database uses PostgreSQL with vector extensions for AI embeddings
+- Content generation involves complex AI workflows with Mastra
+- Authentication is handled via Clerk across all applications
+- Repository pattern implementation is mandatory for all data access
+- Test factory usage is mandatory - no inline test data objects

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,3 +190,9 @@ src/
 - Authentication is handled via Clerk across all applications
 - Repository pattern implementation is mandatory for all data access
 - Test factory usage is mandatory - no inline test data objects
+
+## Backlog MCP Server利用時の考慮事項
+
+Backlog MCP Serverを使用する際は、以下のプロジェクトキーのプロジェクトの情報を利用すること
+- TPC
+課題（チケット）、Wikiという文脈から利用を判断すること

--- a/apps/lp-frontend/nuxt.config.ts
+++ b/apps/lp-frontend/nuxt.config.ts
@@ -77,7 +77,11 @@ export default defineNuxtConfig({
     '/app/**': {
       ssr: false,
       prerender: false,
-      headers: { 'cache-control': 'no-cache' },
+      headers: {
+        'cache-control': 'no-cache, no-store, must-revalidate',
+        'pragma': 'no-cache',
+        'expires': '0',
+      },
     },
 
     // API関連: SSRなし、キャッシュなし

--- a/apps/lp-frontend/src/composables/useAuthGuard.ts
+++ b/apps/lp-frontend/src/composables/useAuthGuard.ts
@@ -1,0 +1,257 @@
+/**
+ * 認証ガード用のcomposable
+ *
+ * 統一された認証状態チェックとエラーハンドリングを提供します。
+ * ローカル環境とCloudflare Pages環境での認証初期化遅延に対応します。
+ */
+
+import { useUIState } from './useUIState';
+
+/**
+ * 認証状態の結果を表すインターフェース
+ */
+export interface AuthResult {
+  /** 認証済みかどうか */
+  isAuthenticated: boolean;
+  /** ユーザーID（認証済みの場合） */
+  userId: string | null;
+  /** エラー情報（エラーが発生した場合） */
+  error: AuthError | null;
+  /** ローディング中かどうか */
+  isLoading: boolean;
+}
+
+/**
+ * 認証エラーの詳細情報を表すインターフェース
+ */
+export interface AuthError {
+  /** エラーコード */
+  code: 'INITIALIZATION_TIMEOUT' | 'INITIALIZATION_FAILED' | 'AUTHENTICATION_REQUIRED';
+  /** エラーメッセージ */
+  message: string;
+  /** 元のエラーオブジェクト（存在する場合） */
+  originalError?: unknown;
+}
+
+/**
+ * 認証ガードのオプション設定を表すインターフェース
+ */
+export interface AuthGuardOptions {
+  /** 認証初期化の最大待機時間（ミリ秒） */
+  maxWaitTime?: number;
+  /** ポーリング間隔（ミリ秒） */
+  pollInterval?: number;
+  /** ローディング表示を行うかどうか */
+  showLoading?: boolean;
+  /** タイムアウト時のエラーメッセージを表示するかどうか */
+  showError?: boolean;
+}
+
+/**
+ * 認証ガードの戻り値を表すインターフェース
+ */
+interface UseAuthGuardReturn {
+  /** 認証状態が初期化されるまで待機 */
+  waitForAuth: (options?: AuthGuardOptions) => Promise<AuthResult>;
+  /** 認証が必要なページでの認証チェック */
+  ensureAuthenticated: (options?: AuthGuardOptions) => Promise<AuthResult>;
+  /** 現在の認証状態を即座に取得（初期化を待機しない） */
+  getCurrentAuthState: () => AuthResult;
+  /** 認証状態の変化を監視 */
+  watchAuthState: (callback: (result: AuthResult) => void) => void;
+}
+
+export const useAuthGuard = (): UseAuthGuardReturn => {
+  const { showLoading, hideLoading, showError } = useUIState();
+
+  /**
+   * 認証状態が初期化されるまで待機
+   */
+  const waitForAuth = async (options: AuthGuardOptions = {}): Promise<AuthResult> => {
+    const {
+      maxWaitTime = 10000, // 10秒に延長
+      pollInterval = 100,
+      showLoading: shouldShowLoading = false,
+      showError: shouldShowError = true,
+    } = options;
+
+    const { userId, isLoaded } = useAuth();
+
+    // 既に初期化されている場合は即座に結果を返す
+    if (isLoaded.value) {
+      return {
+        isAuthenticated: !!userId.value,
+        userId: userId.value,
+        error: null,
+        isLoading: false,
+      };
+    }
+
+    // ローディング表示
+    if (shouldShowLoading) {
+      showLoading({
+        message: '認証状態を確認中...',
+        overlay: true,
+      });
+    }
+
+    let attempts = 0;
+    const maxAttempts = Math.floor(maxWaitTime / pollInterval);
+
+    try {
+      while (!isLoaded.value && attempts < maxAttempts) {
+        await new Promise((resolve) => setTimeout(resolve, pollInterval));
+        attempts++;
+      }
+
+      // ローディング非表示
+      if (shouldShowLoading) {
+        hideLoading();
+      }
+
+      // 初期化がタイムアウトした場合
+      if (!isLoaded.value) {
+        const error: AuthError = {
+          code: 'INITIALIZATION_TIMEOUT',
+          message: `認証の初期化がタイムアウトしました (${maxWaitTime}ms)`,
+        };
+
+        if (shouldShowError) {
+          showError(error.message, {
+            title: '認証エラー',
+            autoHideDelay: 5000,
+          });
+        }
+
+        console.warn('Auth initialization timeout:', {
+          attempts,
+          maxAttempts,
+          maxWaitTime,
+          pollInterval,
+        });
+
+        return {
+          isAuthenticated: false,
+          userId: null,
+          error,
+          isLoading: false,
+        };
+      }
+
+      // 初期化完了
+      console.log('Auth initialization completed:', {
+        isLoaded: isLoaded.value,
+        userId: userId.value,
+        attempts,
+        timeElapsed: attempts * pollInterval,
+      });
+
+      return {
+        isAuthenticated: !!userId.value,
+        userId: userId.value,
+        error: null,
+        isLoading: false,
+      };
+    } catch (originalError) {
+      // ローディング非表示
+      if (shouldShowLoading) {
+        hideLoading();
+      }
+
+      const error: AuthError = {
+        code: 'INITIALIZATION_FAILED',
+        message: '認証の初期化に失敗しました',
+        originalError,
+      };
+
+      if (shouldShowError) {
+        showError(error.message, {
+          title: '認証エラー',
+          autoHideDelay: 5000,
+        });
+      }
+
+      console.error('Auth initialization failed:', originalError);
+
+      return {
+        isAuthenticated: false,
+        userId: null,
+        error,
+        isLoading: false,
+      };
+    }
+  };
+
+  /**
+   * 認証が必要なページでの認証チェック
+   */
+  const ensureAuthenticated = async (options: AuthGuardOptions = {}): Promise<AuthResult> => {
+    const result = await waitForAuth(options);
+
+    if (result.error) {
+      return result;
+    }
+
+    if (!result.isAuthenticated) {
+      const error: AuthError = {
+        code: 'AUTHENTICATION_REQUIRED',
+        message: '認証が必要です',
+      };
+
+      if (options.showError !== false) {
+        showError(error.message, {
+          title: 'アクセス拒否',
+          autoHideDelay: 3000,
+        });
+      }
+
+      return {
+        ...result,
+        error,
+      };
+    }
+
+    return result;
+  };
+
+  /**
+   * 現在の認証状態を即座に取得（初期化を待機しない）
+   */
+  const getCurrentAuthState = (): AuthResult => {
+    const { userId, isLoaded } = useAuth();
+
+    if (!isLoaded.value) {
+      return {
+        isAuthenticated: false,
+        userId: null,
+        error: null,
+        isLoading: true,
+      };
+    }
+
+    return {
+      isAuthenticated: !!userId.value,
+      userId: userId.value,
+      error: null,
+      isLoading: false,
+    };
+  };
+
+  /**
+   * 認証状態の変化を監視
+   */
+  const watchAuthState = (callback: (result: AuthResult) => void): void => {
+    const { userId, isLoaded } = useAuth();
+
+    watch([userId, isLoaded], () => {
+      callback(getCurrentAuthState());
+    }, { immediate: true });
+  };
+
+  return {
+    waitForAuth,
+    ensureAuthenticated,
+    getCurrentAuthState,
+    watchAuthState,
+  };
+};

--- a/apps/lp-frontend/src/middleware/auth.global.ts
+++ b/apps/lp-frontend/src/middleware/auth.global.ts
@@ -1,45 +1,75 @@
+import { useAuthGuard } from '~/composables/useAuthGuard';
+
 const isProtectedRoute = createRouteMatcher(['/dashboard(.*)', '/app/(.*)']);
 const isLoginPage = createRouteMatcher(['/login']);
 
 export default defineNuxtRouteMiddleware(async (to) => {
   console.log('Auth middleware called for:', to.path);
 
-  const { userId, isLoaded } = useAuth();
+  const { waitForAuth } = useAuthGuard();
 
-  // 認証の初期化を待つ（最大5秒間）
-  let attempts = 0;
-  const maxAttempts = 50; // 5秒間（100ms × 50回）
+  try {
+    // 統一された認証待機処理を使用（10秒タイムアウト）
+    const authResult = await waitForAuth({
+      maxWaitTime: 10000,
+      pollInterval: 100,
+      showLoading: false, // グローバルミドルウェアではローディング表示を無効
+      showError: false, // エラーメッセージも無効（ログ出力のみ）
+    });
 
-  while (!isLoaded.value && attempts < maxAttempts) {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    attempts++;
+    console.log('Auth middleware result:', {
+      isAuthenticated: authResult.isAuthenticated,
+      userId: authResult.userId,
+      error: authResult.error?.code,
+      path: to.path,
+    });
+
+    // 認証初期化でエラーが発生した場合の処理
+    if (authResult.error) {
+      console.warn('Auth initialization error:', authResult.error);
+
+      // タイムアウトエラーの場合は処理をスキップ（従来の動作を維持）
+      if (authResult.error.code === 'INITIALIZATION_TIMEOUT') {
+        console.warn('Authentication initialization timeout, skipping auth middleware');
+        return;
+      }
+
+      // その他のエラーの場合も処理をスキップ
+      console.warn('Authentication error, skipping auth middleware');
+      return;
+    }
+
+    // 認証済みユーザーがログインページにアクセスした場合
+    if (authResult.isAuthenticated && isLoginPage(to)) {
+      console.log('Redirecting logged-in user from login page to dashboard');
+      return navigateTo('/dashboard');
+    }
+
+    // 未認証ユーザーが保護されたルートにアクセスした場合
+    if (!authResult.isAuthenticated && isProtectedRoute(to)) {
+      console.log('Redirecting unauthenticated user to login page');
+      return navigateTo('/login');
+    }
+
+    console.log('Auth middleware completed, no redirect needed');
+  } catch (error) {
+    // 予期しないエラーが発生した場合
+    console.error('Unexpected error in auth middleware:', error);
+
+    // エラーが発生した場合は従来のフォールバック処理
+    const { userId, isLoaded } = useAuth();
+
+    if (!isLoaded.value) {
+      console.warn('Authentication not loaded after error, skipping auth middleware');
+      return;
+    }
+
+    if (userId.value && isLoginPage(to)) {
+      return navigateTo('/dashboard');
+    }
+
+    if (!userId.value && isProtectedRoute(to)) {
+      return navigateTo('/login');
+    }
   }
-
-  console.log('Auth state:', {
-    isLoaded: isLoaded.value,
-    userId: userId.value,
-    attempts,
-    path: to.path,
-  });
-
-  // 認証が読み込まれていない場合は処理をスキップ
-  if (!isLoaded.value) {
-    console.warn('Authentication not loaded, skipping auth middleware');
-    return;
-  }
-
-  if (userId.value && isLoginPage(to)) {
-    // If the user is already signed in, they are redirected to the dashboard
-    console.log('Redirecting logged-in user from login page to dashboard');
-    return navigateTo('/dashboard');
-  }
-
-  // If the user is not signed in, they aren't allowed to access
-  // the protected route and are redirected to the sign-in page
-  if (!userId.value && isProtectedRoute(to)) {
-    console.log('Redirecting unauthenticated user to login page');
-    return navigateTo('/login');
-  }
-
-  console.log('Auth middleware completed, no redirect needed');
 });

--- a/apps/lp-frontend/src/middleware/spa-fallback.global.ts
+++ b/apps/lp-frontend/src/middleware/spa-fallback.global.ts
@@ -1,29 +1,102 @@
-export default defineNuxtRouteMiddleware((to) => {
+import { useAuthGuard } from '~/composables/useAuthGuard';
+
+export default defineNuxtRouteMiddleware(async (to) => {
+  console.log('SPA fallback middleware called for:', to.path);
+
   // SPAルート（/app/**）の処理
   if (to.path.startsWith('/app/')) {
     // 開発環境では SPAフォールバックを無効にする
     if (import.meta.dev) {
+      console.log('Development environment, skipping SPA fallback');
       return;
     }
 
-    // 認証状態を確認（本番環境のみ）
-    const { userId } = useAuth();
+    const { waitForAuth } = useAuthGuard();
 
-    // ログインしていない場合は認証ミドルウェアに任せる
-    if (!userId.value) {
-      return;
-    }
+    try {
+      // 認証状態を確実に待機（本番環境のみ）
+      console.log('Waiting for authentication initialization in SPA fallback...');
 
-    // SSGビルドでクライアントサイドの場合
-    if (import.meta.client && import.meta.env.MODE === 'production') {
-      // ルートが存在するかチェック
-      const router = useRouter();
-      const route = router.resolve(to.path);
+      const authResult = await waitForAuth({
+        maxWaitTime: 8000, // グローバルミドルウェアより短く設定
+        pollInterval: 100,
+        showLoading: true, // SPAフォールバック時はローディング表示
+        showError: false, // エラーメッセージは無効（ログ出力のみ）
+      });
 
-      if (route.matched.length === 0) {
-        // 存在しないルートの場合、ダッシュボードにリダイレクト
-        console.warn(`Route not found: ${to.path}, redirecting to dashboard`);
-        return navigateTo('/app/dashboard');
+      console.log('SPA fallback auth result:', {
+        isAuthenticated: authResult.isAuthenticated,
+        userId: authResult.userId,
+        error: authResult.error?.code,
+        path: to.path,
+      });
+
+      // 認証初期化でエラーが発生した場合
+      if (authResult.error) {
+        console.warn('Auth error in SPA fallback:', authResult.error);
+
+        // タイムアウトまたは初期化失敗の場合、ログインページにリダイレクト
+        if (authResult.error.code === 'INITIALIZATION_TIMEOUT' ||
+          authResult.error.code === 'INITIALIZATION_FAILED') {
+          console.warn('Auth initialization failed, redirecting to login');
+          return navigateTo('/login');
+        }
+
+        // 認証が必要なエラーの場合もログインページへ
+        if (authResult.error.code === 'AUTHENTICATION_REQUIRED') {
+          console.warn('Authentication required, redirecting to login');
+          return navigateTo('/login');
+        }
+      }
+
+      // 認証済みユーザーの場合のみルート存在チェックを実行
+      if (authResult.isAuthenticated) {
+        // SSGビルドでクライアントサイドの場合
+        if (import.meta.client && import.meta.env.MODE === 'production') {
+          // ルートが存在するかチェック
+          const router = useRouter();
+          const route = router.resolve(to.path);
+
+          if (route.matched.length === 0) {
+            // 存在しないルートの場合、ダッシュボードにリダイレクト
+            console.warn(`Route not found: ${to.path}, redirecting to dashboard`);
+            return navigateTo('/app/dashboard');
+          }
+        }
+
+        console.log('SPA fallback completed, route is valid');
+      } else {
+        // 未認証ユーザーは auth.global.ts に処理を委ねる
+        console.log('User not authenticated, delegating to auth middleware');
+      }
+    } catch (error) {
+      // 予期しないエラーが発生した場合
+      console.error('Unexpected error in SPA fallback middleware:', error);
+
+      // フォールバック: 従来の処理
+      const { userId, isLoaded } = useAuth();
+
+      // 認証がロードされていない場合はログインページへ
+      if (!isLoaded.value) {
+        console.warn('Authentication not loaded in SPA fallback, redirecting to login');
+        return navigateTo('/login');
+      }
+
+      // ログインしていない場合は認証ミドルウェアに任せる
+      if (!userId.value) {
+        console.log('User not authenticated in fallback, delegating to auth middleware');
+        return;
+      }
+
+      // 認証済みの場合はルートチェックのみ実行
+      if (import.meta.client && import.meta.env.MODE === 'production') {
+        const router = useRouter();
+        const route = router.resolve(to.path);
+
+        if (route.matched.length === 0) {
+          console.warn(`Route not found in fallback: ${to.path}, redirecting to dashboard`);
+          return navigateTo('/app/dashboard');
+        }
       }
     }
   }

--- a/apps/lp-frontend/src/pages/app/programs/[id].vue
+++ b/apps/lp-frontend/src/pages/app/programs/[id].vue
@@ -48,6 +48,8 @@ v-container(class="max-width-container")
 </template>
 
 <script setup lang="ts">
+import { useAuthGuard } from '~/composables/useAuthGuard';
+
 // レイアウトをuser-appにする
 definePageMeta({
   layout: 'user-app',
@@ -55,9 +57,6 @@ definePageMeta({
 
 const route = useRoute();
 const programId = route.params.id as string;
-
-// 認証状態を確認
-const { userId, isLoaded } = useAuth();
 
 // プログラム詳細データを取得
 const { data, error, pending } = await useAsyncData(`program-detail-${programId}`, async () => {
@@ -68,16 +67,57 @@ const { data, error, pending } = await useAsyncData(`program-detail-${programId}
     });
   }
 
-  // 認証の初期化を待つ
-  while (!isLoaded.value) {
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
+  // 統一された認証チェックを使用
+  const { ensureAuthenticated } = useAuthGuard();
+  
+  try {
+    const authResult = await ensureAuthenticated({
+      maxWaitTime: 5000,    // ページレベルでは5秒タイムアウト
+      pollInterval: 100,
+      showLoading: true,    // ページレベルではローディング表示
+      showError: true,      // エラーメッセージも表示
+    });
 
-  // 認証されていない場合
-  if (!userId.value) {
+    // 認証エラーの場合
+    if (authResult.error) {
+      console.error('認証エラー in program detail page:', authResult.error);
+      
+      if (authResult.error.code === 'INITIALIZATION_TIMEOUT') {
+        throw createError({
+          statusCode: 408,
+          statusMessage: '認証の初期化がタイムアウトしました。ページを再読み込みしてください。',
+        });
+      } else if (authResult.error.code === 'INITIALIZATION_FAILED') {
+        throw createError({
+          statusCode: 500,
+          statusMessage: '認証の初期化に失敗しました。しばらく待ってから再試行してください。',
+        });
+      } else if (authResult.error.code === 'AUTHENTICATION_REQUIRED') {
+        throw createError({
+          statusCode: 401,
+          statusMessage: '認証が必要です',
+        });
+      }
+    }
+
+    // 認証されていない場合
+    if (!authResult.isAuthenticated) {
+      throw createError({
+        statusCode: 401,
+        statusMessage: '認証が必要です',
+      });
+    }
+
+    console.log('Program detail page - authentication successful:', {
+      userId: authResult.userId,
+      programId,
+    });
+
+  } catch (authError) {
+    console.error('認証チェックで予期しないエラー:', authError);
     throw createError({
-      statusCode: 401,
-      statusMessage: '認証が必要です',
+      statusCode: 500,
+      statusMessage: '認証チェックに失敗しました',
     });
   }
 
@@ -99,6 +139,11 @@ const { data, error, pending } = await useAsyncData(`program-detail-${programId}
         throw createError({
           statusCode: 401,
           statusMessage: '認証が必要です',
+        });
+      } else if (errorResponse.response?.status === 403) {
+        throw createError({
+          statusCode: 403,
+          statusMessage: 'このプログラムにアクセスする権限がありません',
         });
       }
     }

--- a/apps/lp-frontend/src/pages/app/programs/[id].vue
+++ b/apps/lp-frontend/src/pages/app/programs/[id].vue
@@ -69,19 +69,19 @@ const { data, error, pending } = await useAsyncData(`program-detail-${programId}
 
   // 統一された認証チェックを使用
   const { ensureAuthenticated } = useAuthGuard();
-  
+
   try {
     const authResult = await ensureAuthenticated({
-      maxWaitTime: 5000,    // ページレベルでは5秒タイムアウト
+      maxWaitTime: 5000, // ページレベルでは5秒タイムアウト
       pollInterval: 100,
-      showLoading: true,    // ページレベルではローディング表示
-      showError: true,      // エラーメッセージも表示
+      showLoading: true, // ページレベルではローディング表示
+      showError: true, // エラーメッセージも表示
     });
 
     // 認証エラーの場合
     if (authResult.error) {
       console.error('認証エラー in program detail page:', authResult.error);
-      
+
       if (authResult.error.code === 'INITIALIZATION_TIMEOUT') {
         throw createError({
           statusCode: 408,
@@ -112,7 +112,6 @@ const { data, error, pending } = await useAsyncData(`program-detail-${programId}
       userId: authResult.userId,
       programId,
     });
-
   } catch (authError) {
     console.error('認証チェックで予期しないエラー:', authError);
     throw createError({


### PR DESCRIPTION
## 概要
  Cloudflare Pages環境でログイン状態であっても番組詳細画面などに直接アクセスするとトップページが表示される問題を修正しました。

  ## 問題
  - ローカル環境では正常動作するが、Cloudflare Pages環境で直接URLアクセス時にトップページへリダイレクトされる
  - Clerk認証の初期化遅延とSPAフォールバック処理の不備が原因

  ## 解決策
  5つのフェーズに分けて段階的に修正を実施：

  ### 🔧 主要な変更点

  #### 1. 認証待機ロジックの統一化
  - **新規作成**: `src/composables/useAuthGuard.ts`
  - 統一された認証待機処理（10秒タイムアウト）
  - 初期化失敗時のエラーハンドリング
  - ローディング状態管理

  #### 2. グローバルミドルウェアの修正
  - **修正**: `src/middleware/auth.global.ts`
  - 認証タイムアウト時間延長（5秒→10秒）
  - useAuthGuard使用への統一
  - 初期化失敗時のフォールバック処理追加

  #### 3. SPAフォールバック処理の強化
  - **修正**: `src/middleware/spa-fallback.global.ts`
  - 認証初期化完了の確実な待機
  - 認証済みユーザーの不適切なリダイレクト防止
  - ローディング状態表示

  #### 4. 番組詳細ページの改善
  - **修正**: `src/pages/app/programs/[id].vue`
  - 重複する認証待機処理の削除
  - useAuthGuard使用への変更
  - エラーハンドリングの改善

  #### 5. Nuxt設定の最適化
  - **修正**: `nuxt.config.ts`
  - 認証ページのキャッシュ戦略強化
  - 完全なキャッシュ無効化ヘッダー追加

  ## 📈 期待される効果
  1. Cloudflare Pages環境での直接URLアクセス時の正常動作
  2. 認証初期化遅延に対する耐性向上
  3. ローカル環境と本番環境の動作統一
  4. ユーザーエクスペリエンスの改善

  ## ⚠️ 注意事項
  - 事前レンダリングページ（`/headline-topic-programs/**`）への影響なし
  - 認証ページ（`/app/**`）のみが対象の安全な変更
  - 後方互換性を維持

  ## 🔗 関連
  - Backlog: TPC-135
  - 影響範囲: 認証関連ページのみ
  - 破壊的変更: なし

  コミット履歴

  8e875bf feat(auth): Nuxt設定の最適化 - キャッシュ戦略強化 (TPC-135)
  f0f494c feat(auth): 番組詳細ページの改善 (TPC-135)
  b50cc21 feat(auth): SPAフォールバック処理の強化 (TPC-135)
  f038ed1 feat(auth): グローバルミドルウェアの修正 (TPC-135)
  5f4c0ba feat(auth): 認証待機ロジックの統一化 (TPC-135)

  ファイル変更一覧

  新規作成:
  - src/composables/useAuthGuard.ts

  修正:
  - src/middleware/auth.global.ts
  - src/middleware/spa-fallback.global.ts
  - src/pages/app/programs/[id].vue
  - nuxt.config.ts