### PR TITLE
fix(spa): Cloudflare Pages環境でのSPAフォールバック設定修正 (TPC-135)

### DIFF
--- a/apps/lp-frontend/nuxt.config.ts
+++ b/apps/lp-frontend/nuxt.config.ts
@@ -161,10 +161,13 @@ export default defineNuxtConfig({
             // 静的ホスティング用の _redirects ファイルを生成
             const redirectsPath = path.join(publicDir, '_redirects');
             const redirectsContent = [
-              '# SPA fallback for /app routes',
-              '/app/* /200.html 200',
+              '# SPA fallback for /app routes - preserve original URL with force flag',
+              '/app/* /200.html 200!',
               '',
-              '# Default fallback',
+              '# Login page fallback - preserve original URL with force flag',
+              '/login /200.html 200!',
+              '',
+              '# Default fallback for other routes',
               '/* /index.html 200',
             ].join('\n');
             fs.writeFileSync(redirectsPath, redirectsContent);


### PR DESCRIPTION
## 概要
  Cloudflare Pages環境でのテスト結果を受けて、SPAフォールバック設定の根本的な問題を修正しました。

  ## 問題の詳細
  フェーズ1-5の修正後もCloudflare Pages環境で問題が継続していた原因を特定：

  ### 環境別の処理フロー差異
  **ローカル環境（正常動作）**:
  - Nuxt開発サーバーがリアルタイムでページをレンダリング
  - `/app/programs/123` → 直接番組詳細ページコンポーネントにrouting

  **Cloudflare Pages環境（問題発生）**:
  - `/app/programs/123` → _redirectsにより`/200.html`にリダイレクト
  - ブラウザURLは`/app/programs/123`のままだが、実際のコンテンツはトップページ
  - **Nuxtルーターが現在のパスを`"/"`として誤認識**

  ### 実際のログ解析結果
  番組詳細ページアクセス: /app/programs/123
  ↓ _redirects処理でSPAフォールバック
  実際の読み込み: /200.html (index.htmlのコピー)
  ↓ 認証ミドルウェア実行時
  認識されるパス: "/" (トップページとして誤認識)

  ## 🔧 修正内容

  ### _redirects設定の改善
  **修正前**:
  /app/* /200.html 200
  /* /index.html 200

  **修正後**:
  SPA fallback for /app routes - preserve original URL with force flag

  /app/* /200.html 200!

  Login page fallback - preserve original URL with force flag

  /login /200.html 200!

  Default fallback for other routes

  /* /index.html 200

  ### 変更のポイント

  #### 1. 200!フラグの追加
  - `200` → `200!` に変更
  - Cloudflareに対してこのリダイレクトを強制実行するよう指示
  - 他のルールより優先してこの設定を適用

  #### 2. ログインページの個別設定
  - `/login /200.html 200!` を追加
  - ログインページも同様の強制フォールバック処理

  #### 3. 優先順位の明確化
  - 認証ページ（`/app/*`, `/login`）を最優先
  - その他のページは従来通りの処理

  ## 📈 期待される効果

  この修正により、Cloudflare Pages環境で：
  1. `/app/programs/123` にアクセス → `200.html` にリダイレクト
  2. **URLは `/app/programs/123` のまま維持**
  3. Nuxtルーターが正しいパス（`/app/programs/123`）として認識
  4. 認証ミドルウェアが適切なページとして処理

  ## ⚠️ 注意事項
  - 静的ファイル配信の仕組みを利用したCloudflare Pages特有の修正
  - ローカル環境では影響なし（開発サーバーは_redirectsを使用しない）
  - 事前レンダリングページ（`/headline-topic-programs/**`）への影響なし

  ## 🔗 関連
  - Backlog: TPC-135
  - 前回PR: [前回のPR番号]の追加修正
  - 影響範囲: Cloudflare Pages環境のSPAルーティングのみ
  - 破壊的変更: なし

  ## ✅ テスト結果
  - ローカル環境での動作確認: 正常
  - ビルドプロセス: 正常
  - _redirectsファイル生成: 正常

  コミット情報

  修正ファイル:
  - nuxt.config.ts

  コミットメッセージ案:
  fix(spa): Cloudflare Pages環境でのSPAフォールバック設定修正 (TPC-135)

  - _redirects設定に200!フラグを追加してCloudflareでの強制リダイレクト
  - /loginページの個別フォールバック設定を追加
  - 認証ページの優先順位を明確化
  - URLを維持したままの正しいSPAフォールバック処理を実現